### PR TITLE
ci: don't use coverage for examples or bin targets

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: 'tarpaulin'
-          args: '--out Xml --run-types DocTests --all-targets -- --test-threads 1'
+          args: '--out Xml --lib --tests --doc -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3.1.1


### PR DESCRIPTION
They generally don't have tests and are not CI checked.