### PR TITLE
Improve cargo test logging

### DIFF
--- a/stun-proto/Cargo.toml
+++ b/stun-proto/Cargo.toml
@@ -18,4 +18,4 @@ tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", features = ["env-filter"]}
+tracing-subscriber = "0.3"

--- a/stun-proto/src/agent.rs
+++ b/stun-proto/src/agent.rs
@@ -677,12 +677,9 @@ impl From<StunWriteError> for StunError {
 pub(crate) mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn agent_getters_setters() {
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
         let mut agent = StunAgent::builder(TransportType::Udp, local_addr)
@@ -708,7 +705,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "127.0.0.1:2000".parse().unwrap();
         let remote_addr = "127.0.0.1:1000".parse().unwrap();
         let mut agent = StunAgent::builder(TransportType::Udp, local_addr)
@@ -736,7 +733,7 @@ pub(crate) mod tests {
 
     #[test]
     fn indication_with_invalid_response() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "127.0.0.1:2000".parse().unwrap();
         let remote_addr = "127.0.0.1:1000".parse().unwrap();
         let mut agent = StunAgent::builder(TransportType::Udp, local_addr)
@@ -768,7 +765,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_with_credentials() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -822,7 +819,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_unanswered() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "127.0.0.1:2000".parse().unwrap();
         let remote_addr = "127.0.0.1:1000".parse().unwrap();
         let mut agent = StunAgent::builder(TransportType::Udp, local_addr)
@@ -851,7 +848,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_without_credentials() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -888,7 +885,7 @@ pub(crate) mod tests {
 
     #[test]
     fn response_without_credentials() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -929,7 +926,7 @@ pub(crate) mod tests {
 
     #[test]
     fn agent_response_without_credentials() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -968,7 +965,7 @@ pub(crate) mod tests {
 
     #[test]
     fn response_with_incorrect_credentials() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1010,7 +1007,7 @@ pub(crate) mod tests {
 
     #[test]
     fn duplicate_response_ignored() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1043,6 +1040,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_cancel() {
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1070,6 +1068,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_cancel_send() {
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1102,6 +1101,7 @@ pub(crate) mod tests {
 
     #[test]
     fn request_duplicate() {
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1140,6 +1140,7 @@ pub(crate) mod tests {
 
     #[test]
     fn incoming_request() {
+        let _log = crate::tests::test_init_log();
         let local_addr = "10.0.0.1:12345".parse().unwrap();
         let remote_addr = "10.0.0.2:3478".parse().unwrap();
 
@@ -1158,7 +1159,7 @@ pub(crate) mod tests {
 
     #[test]
     fn tcp_request() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "127.0.0.1:2000".parse().unwrap();
         let remote_addr = "127.0.0.1:1000".parse().unwrap();
         let mut agent = StunAgent::builder(TransportType::Tcp, local_addr)
@@ -1178,7 +1179,7 @@ pub(crate) mod tests {
 
     #[test]
     fn tcp_buffer_split_recv() {
-        init();
+        let _log = crate::tests::test_init_log();
 
         let mut tcp_buffer = TcpBuffer::default();
 

--- a/stun-proto/src/lib.rs
+++ b/stun-proto/src/lib.rs
@@ -98,16 +98,27 @@ impl<T> DebugWrapper<T> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Once;
-    use tracing_subscriber::EnvFilter;
+    use tracing::subscriber::DefaultGuard;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
 
-    static TRACING: Once = Once::new();
-
-    pub fn test_init_log() {
-        TRACING.call_once(|| {
-            if let Ok(filter) = EnvFilter::try_from_default_env() {
-                tracing_subscriber::fmt().with_env_filter(filter).init();
-            }
-        });
+    pub fn test_init_log() -> DefaultGuard {
+        let level_filter = std::env::var("STUN_LOG")
+            .or(std::env::var("RUST_LOG"))
+            .ok()
+            .and_then(|var| var.parse::<tracing_subscriber::filter::Targets>().ok())
+            .unwrap_or(
+                tracing_subscriber::filter::Targets::new().with_default(tracing::Level::TRACE),
+            );
+        let registry = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_file(true)
+                .with_line_number(true)
+                .with_level(true)
+                .with_target(false)
+                .with_test_writer()
+                .with_filter(level_filter),
+        );
+        tracing::subscriber::set_default(registry)
     }
 }

--- a/stun-types/Cargo.toml
+++ b/stun-types/Cargo.toml
@@ -24,7 +24,7 @@ arbitrary ={ workspace = true, optional = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", features = ["env-filter"]}
+tracing-subscriber = "0.3"
 
 [features]
 arbitrary = ["dep:arbitrary"]

--- a/stun-types/src/attribute/alternate.rs
+++ b/stun-types/src/attribute/alternate.rs
@@ -156,13 +156,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn alternate_server() {
-        init();
+        let _log = crate::tests::test_init_log();
         let addrs = &[
             "192.168.0.1:40000".parse().unwrap(),
             "[fd12:3456:789a:1::1]:41000".parse().unwrap(),
@@ -203,7 +199,7 @@ mod tests {
 
     #[test]
     fn alternative_domain() {
-        init();
+        let _log = crate::tests::test_init_log();
         let dns = "example.com";
         let attr = AlternateDomain::new(dns);
         assert_eq!(attr.domain(), dns);

--- a/stun-types/src/attribute/error.rs
+++ b/stun-types/src/attribute/error.rs
@@ -332,13 +332,9 @@ mod tests {
     use super::*;
     use crate::attribute::{AlternateServer, Nonce, Realm};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn error_code() {
-        init();
+        let _log = crate::tests::test_init_log();
         let codes = [300, 401, 699];
         for code in codes.iter().copied() {
             let reason = ErrorCode::default_reason_for_code(code);
@@ -360,6 +356,7 @@ mod tests {
 
     #[test]
     fn error_code_parse_short() {
+        let _log = crate::tests::test_init_log();
         let err = error_code_new(420);
         let raw = RawAttribute::from(&err);
         // no data
@@ -377,6 +374,7 @@ mod tests {
 
     #[test]
     fn error_code_parse_wrong_implementation() {
+        let _log = crate::tests::test_init_log();
         let err = error_code_new(420);
         let raw = RawAttribute::from(&err);
         // provide incorrectly typed data
@@ -390,6 +388,7 @@ mod tests {
 
     #[test]
     fn error_code_parse_out_of_range_code() {
+        let _log = crate::tests::test_init_log();
         let err = error_code_new(420);
         let raw = RawAttribute::from(&err);
         let mut data: Vec<_> = raw.into();
@@ -404,6 +403,7 @@ mod tests {
 
     #[test]
     fn error_code_parse_invalid_reason() {
+        let _log = crate::tests::test_init_log();
         let err = error_code_new(420);
         let raw = RawAttribute::from(&err);
         let mut data: Vec<_> = raw.into();
@@ -418,6 +418,7 @@ mod tests {
 
     #[test]
     fn error_code_build_default_reason() {
+        let _log = crate::tests::test_init_log();
         let err = ErrorCode::builder(420).build().unwrap();
         assert_eq!(err.code(), 420);
         assert!(err.reason().len() > 0);
@@ -425,6 +426,7 @@ mod tests {
 
     #[test]
     fn error_code_build_out_of_range() {
+        let _log = crate::tests::test_init_log();
         assert!(matches!(
             ErrorCode::builder(700).build(),
             Err(StunWriteError::OutOfRange {
@@ -437,6 +439,7 @@ mod tests {
 
     #[test]
     fn error_code_new_out_of_range() {
+        let _log = crate::tests::test_init_log();
         assert!(matches!(
             ErrorCode::new(700, "some-reason"),
             Err(StunWriteError::OutOfRange {
@@ -449,7 +452,7 @@ mod tests {
 
     #[test]
     fn unknown_attributes() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut unknown = UnknownAttributes::new(&[Realm::TYPE]);
         unknown.add_attribute(AlternateServer::TYPE);
         // duplicates ignored

--- a/stun-types/src/attribute/fingerprint.rs
+++ b/stun-types/src/attribute/fingerprint.rs
@@ -104,13 +104,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 4];
         let attr = Fingerprint::new(val);
         assert_eq!(attr.fingerprint(), &val);

--- a/stun-types/src/attribute/ice.rs
+++ b/stun-types/src/attribute/ice.rs
@@ -266,13 +266,9 @@ impl std::fmt::Display for IceControlling {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn priority() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = 100;
         let priority = Priority::new(val);
         assert_eq!(priority.priority(), val);
@@ -303,7 +299,7 @@ mod tests {
 
     #[test]
     fn use_candidate() {
-        init();
+        let _log = crate::tests::test_init_log();
         let use_candidate = UseCandidate::default();
         assert_eq!(use_candidate.length(), 0);
         let raw = RawAttribute::from(&use_candidate);
@@ -320,7 +316,7 @@ mod tests {
 
     #[test]
     fn ice_controlling() {
-        init();
+        let _log = crate::tests::test_init_log();
         let tb = 100;
         let attr = IceControlling::new(tb);
         assert_eq!(attr.tie_breaker(), tb);
@@ -351,7 +347,7 @@ mod tests {
 
     #[test]
     fn ice_controlled() {
-        init();
+        let _log = crate::tests::test_init_log();
         let tb = 100;
         let attr = IceControlled::new(tb);
         assert_eq!(attr.tie_breaker(), tb);

--- a/stun-types/src/attribute/integrity.rs
+++ b/stun-types/src/attribute/integrity.rs
@@ -292,13 +292,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn message_integrity() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 20];
         let attr = MessageIntegrity::new(val);
         assert_eq!(attr.hmac(), &val);
@@ -331,7 +327,7 @@ mod tests {
 
     #[test]
     fn message_integrity_sha256() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 32];
         let attr = MessageIntegritySha256::new(&val).unwrap();
         assert_eq!(attr.hmac(), &val);
@@ -361,7 +357,7 @@ mod tests {
 
     #[test]
     fn message_integrity_sha256_new_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 33];
         assert!(matches!(
             MessageIntegritySha256::new(&val),
@@ -374,7 +370,7 @@ mod tests {
 
     #[test]
     fn message_integrity_sha256_new_too_small() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 15];
         assert!(matches!(
             MessageIntegritySha256::new(&val),
@@ -387,7 +383,7 @@ mod tests {
 
     #[test]
     fn message_integrity_sha256_new_not_multiple_of_4() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = [1; 19];
         assert!(matches!(
             MessageIntegritySha256::new(&val),

--- a/stun-types/src/attribute/mod.rs
+++ b/stun-types/src/attribute/mod.rs
@@ -537,13 +537,9 @@ impl<'a> From<RawAttribute<'a>> for Vec<u8> {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn attribute_type() {
-        init();
+        let _log = crate::tests::test_init_log();
         let atype = ErrorCode::TYPE;
         let anum: u16 = atype.into();
         assert_eq!(atype, anum.into());
@@ -551,7 +547,7 @@ mod tests {
 
     #[test]
     fn short_attribute_header() {
-        init();
+        let _log = crate::tests::test_init_log();
         let data = [0; 1];
         // not enough data to parse the header
         let res: Result<AttributeHeader, _> = data.as_ref().try_into();
@@ -560,7 +556,7 @@ mod tests {
 
     #[test]
     fn raw_attribute_construct() {
-        init();
+        let _log = crate::tests::test_init_log();
         let a = RawAttribute::new(1.into(), &[80, 160]);
         assert_eq!(a.get_type(), 1.into());
         let bytes: Vec<_> = a.into();
@@ -571,7 +567,7 @@ mod tests {
 
     #[test]
     fn raw_attribute_encoding() {
-        init();
+        let _log = crate::tests::test_init_log();
         let orig = RawAttribute::new(1.into(), &[80, 160]);
         assert_eq!(orig.get_type(), 1.into());
         let mut data: Vec<_> = orig.into();
@@ -589,6 +585,7 @@ mod tests {
 
     #[test]
     fn test_check_len() {
+        let _log = crate::tests::test_init_log();
         assert!(check_len(4, ..).is_ok());
         assert!(check_len(4, 0..).is_ok());
         assert!(check_len(4, 0..8).is_ok());

--- a/stun-types/src/attribute/nonce.rs
+++ b/stun-types/src/attribute/nonce.rs
@@ -90,13 +90,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn nonce() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Nonce::new("nonce").unwrap();
         assert_eq!(attr.nonce(), "nonce");
         assert_eq!(attr.length() as usize, "nonce".len());
@@ -115,7 +111,7 @@ mod tests {
 
     #[test]
     fn nonce_not_utf8() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Nonce::new("nonce").unwrap();
         let raw = RawAttribute::from(&attr);
         let mut data = raw.to_bytes();
@@ -128,7 +124,7 @@ mod tests {
 
     #[test]
     fn nonce_new_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut large = String::new();
         for _i in 0..95 {
             large.push_str("abcdefgh");

--- a/stun-types/src/attribute/password_algorithm.rs
+++ b/stun-types/src/attribute/password_algorithm.rs
@@ -229,13 +229,9 @@ impl std::fmt::Display for PasswordAlgorithm {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn password_algorithms() {
-        init();
+        let _log = crate::tests::test_init_log();
         let vals = [PasswordAlgorithmValue::MD5, PasswordAlgorithmValue::SHA256];
         let attr = PasswordAlgorithms::new(&vals);
         assert_eq!(attr.algorithms(), &vals);
@@ -254,7 +250,7 @@ mod tests {
 
     #[test]
     fn password_algorithm() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = PasswordAlgorithmValue::SHA256;
         let attr = PasswordAlgorithm::new(val);
         assert_eq!(attr.algorithm(), val);
@@ -273,7 +269,7 @@ mod tests {
 
     #[test]
     fn password_algorithm_value_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = PasswordAlgorithmValue::SHA256;
         let attr = PasswordAlgorithm::new(val);
         let raw = RawAttribute::from(&attr);
@@ -290,7 +286,7 @@ mod tests {
 
     #[test]
     fn password_algorithm_value_unknown() {
-        init();
+        let _log = crate::tests::test_init_log();
         let val = PasswordAlgorithmValue::SHA256;
         let attr = PasswordAlgorithm::new(val);
         let raw = RawAttribute::from(&attr);

--- a/stun-types/src/attribute/realm.rs
+++ b/stun-types/src/attribute/realm.rs
@@ -89,13 +89,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn realm() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Realm::new("realm").unwrap();
         assert_eq!(attr.realm(), "realm");
         assert_eq!(attr.length() as usize, "realm".len());
@@ -114,7 +110,7 @@ mod tests {
 
     #[test]
     fn realm_not_utf8() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Realm::new("realm").unwrap();
         let raw = RawAttribute::from(&attr);
         let mut data = raw.to_bytes();
@@ -127,7 +123,7 @@ mod tests {
 
     #[test]
     fn realme_new_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut large = String::new();
         for _i in 0..95 {
             large.push_str("abcdefgh");

--- a/stun-types/src/attribute/software.rs
+++ b/stun-types/src/attribute/software.rs
@@ -94,13 +94,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn software() {
-        init();
+        let _log = crate::tests::test_init_log();
         let software = Software::new("software").unwrap();
         assert_eq!(software.software(), "software");
         assert_eq!(software.length() as usize, "software".len());
@@ -119,7 +115,7 @@ mod tests {
 
     #[test]
     fn software_not_utf8() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Software::new("software").unwrap();
         let raw = RawAttribute::from(&attr);
         let mut data = raw.to_bytes();
@@ -132,7 +128,7 @@ mod tests {
 
     #[test]
     fn software_new_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut large = String::new();
         for _i in 0..95 {
             large.push_str("abcdefgh");

--- a/stun-types/src/attribute/user.rs
+++ b/stun-types/src/attribute/user.rs
@@ -180,13 +180,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn username() {
-        init();
+        let _log = crate::tests::test_init_log();
         let s = "woohoo!";
         let user = Username::new(s).unwrap();
         assert_eq!(user.username(), s);
@@ -206,7 +202,7 @@ mod tests {
 
     #[test]
     fn username_not_utf8() {
-        init();
+        let _log = crate::tests::test_init_log();
         let attr = Username::new("user").unwrap();
         let raw = RawAttribute::from(&attr);
         let mut data = raw.to_bytes();
@@ -219,7 +215,7 @@ mod tests {
 
     #[test]
     fn username_new_too_large() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut large = String::new();
         for _i in 0..64 {
             large.push_str("abcdefgh");
@@ -236,7 +232,7 @@ mod tests {
 
     #[test]
     fn userhash() {
-        init();
+        let _log = crate::tests::test_init_log();
         let hash = Userhash::compute("username", "realm1");
         let attr = Userhash::new(hash);
         assert_eq!(attr.hash(), &hash);

--- a/stun-types/src/attribute/xor_addr.rs
+++ b/stun-types/src/attribute/xor_addr.rs
@@ -87,13 +87,9 @@ mod tests {
     use super::*;
     use byteorder::{BigEndian, ByteOrder};
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn xor_mapped_address() {
-        init();
+        let _log = crate::tests::test_init_log();
         let transaction_id = 0x9876_5432_1098_7654_3210_9876.into();
         let addrs = &[
             "192.168.0.1:40000".parse().unwrap(),

--- a/stun-types/src/data.rs
+++ b/stun-types/src/data.rs
@@ -116,13 +116,9 @@ impl<'a> From<Box<[u8]>> for Data<'a> {
 pub(crate) mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn data_access() {
-        init();
+        let _log = crate::tests::test_init_log();
         let array = [0, 1, 2, 3];
         let borrowed_data = Data::from(array.as_slice());
         assert_eq!(array.as_slice(), &*borrowed_data);

--- a/stun-types/src/lib.rs
+++ b/stun-types/src/lib.rs
@@ -76,19 +76,30 @@ pub mod prelude {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Once;
-    use tracing_subscriber::EnvFilter;
+    use tracing::subscriber::DefaultGuard;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
 
     use super::*;
 
-    static TRACING: Once = Once::new();
-
-    pub fn test_init_log() {
-        TRACING.call_once(|| {
-            if let Ok(filter) = EnvFilter::try_from_default_env() {
-                tracing_subscriber::fmt().with_env_filter(filter).init();
-            }
-        });
+    pub fn test_init_log() -> DefaultGuard {
+        let level_filter = std::env::var("STUN_LOG")
+            .or(std::env::var("RUST_LOG"))
+            .ok()
+            .and_then(|var| var.parse::<tracing_subscriber::filter::Targets>().ok())
+            .unwrap_or(
+                tracing_subscriber::filter::Targets::new().with_default(tracing::Level::TRACE),
+            );
+        let registry = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_file(true)
+                .with_line_number(true)
+                .with_level(true)
+                .with_target(false)
+                .with_test_writer()
+                .with_filter(level_filter),
+        );
+        tracing::subscriber::set_default(registry)
     }
 
     #[test]

--- a/stun-types/src/lib.rs
+++ b/stun-types/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 //! See the [`message`] and [`attribute`] module documentation for examples on use.
 
-use std::error::Error;
 use std::str::FromStr;
 
 pub mod attribute;
@@ -43,17 +42,11 @@ pub enum TransportType {
 }
 
 /// Errors when parsing a [`TransportType`]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ParseTransportTypeError {
+    /// An unknown transport value was provided
+    #[error("Unknown transport value was provided")]
     UnknownTransport,
-}
-
-impl Error for ParseTransportTypeError {}
-
-impl std::fmt::Display for ParseTransportTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
 }
 
 impl FromStr for TransportType {

--- a/stun-types/src/message.rs
+++ b/stun-types/src/message.rs
@@ -1567,13 +1567,9 @@ impl<'a> MessageBuilder<'a> {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn msg_type_roundtrip() {
-        init();
+        let _log = crate::tests::test_init_log();
         /* validate that all methods/classes survive a roundtrip */
         for m in 0..0xfff {
             let classes = vec![
@@ -1592,7 +1588,7 @@ mod tests {
 
     #[test]
     fn msg_roundtrip() {
-        init();
+        let _log = crate::tests::test_init_log();
         /* validate that all methods/classes survive a roundtrip */
         for m in (0x009..0x4ff).step_by(0x123) {
             let classes = vec![
@@ -1621,6 +1617,7 @@ mod tests {
 
     #[test]
     fn unknown_attributes() {
+        let _log = crate::tests::test_init_log();
         let src = Message::builder_request(BINDING).build();
         let src = Message::from_bytes(&src).unwrap();
         let msg = Message::unknown_attributes(&src, &[Software::TYPE]).build();
@@ -1636,6 +1633,7 @@ mod tests {
 
     #[test]
     fn bad_request() {
+        let _log = crate::tests::test_init_log();
         let src = Message::builder_request(BINDING).build();
         let src = Message::from_bytes(&src).unwrap();
         let msg = Message::bad_request(&src).build();
@@ -1649,7 +1647,7 @@ mod tests {
 
     #[test]
     fn fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         let software = Software::new("s").unwrap();
         msg.add_attribute(&software).unwrap();
@@ -1664,7 +1662,7 @@ mod tests {
 
     #[test]
     fn integrity() {
-        init();
+        let _log = crate::tests::test_init_log();
         for algorithm in [IntegrityAlgorithm::Sha1, IntegrityAlgorithm::Sha256] {
             let credentials = ShortTermCredentials::new("secret".to_owned()).into();
             let mut msg = Message::builder_request(BINDING);
@@ -1682,7 +1680,7 @@ mod tests {
 
     #[test]
     fn add_duplicate_integrity() {
-        init();
+        let _log = crate::tests::test_init_log();
         let credentials = ShortTermCredentials::new("secret".to_owned()).into();
         let mut msg = Message::builder_request(BINDING);
         msg.add_message_integrity(&credentials, IntegrityAlgorithm::Sha1)
@@ -1704,7 +1702,7 @@ mod tests {
 
     #[test]
     fn add_attribute_after_integrity() {
-        init();
+        let _log = crate::tests::test_init_log();
         for algorithm in [IntegrityAlgorithm::Sha1, IntegrityAlgorithm::Sha256] {
             let credentials = ShortTermCredentials::new("secret".to_owned()).into();
             let mut msg = Message::builder_request(BINDING);
@@ -1719,7 +1717,7 @@ mod tests {
 
     #[test]
     fn add_integrity_after_fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         for algorithm in [IntegrityAlgorithm::Sha1, IntegrityAlgorithm::Sha256] {
             let credentials = ShortTermCredentials::new("secret".to_owned()).into();
             let mut msg = Message::builder_request(BINDING);
@@ -1733,7 +1731,7 @@ mod tests {
 
     #[test]
     fn duplicate_fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         assert!(matches!(
@@ -1744,7 +1742,7 @@ mod tests {
 
     #[test]
     fn parse_invalid_fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let mut bytes = msg.build();
@@ -1757,7 +1755,7 @@ mod tests {
 
     #[test]
     fn parse_wrong_magic() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let mut bytes = msg.build();
@@ -1770,7 +1768,7 @@ mod tests {
 
     #[test]
     fn parse_attribute_after_integrity() {
-        init();
+        let _log = crate::tests::test_init_log();
         for algorithm in [IntegrityAlgorithm::Sha1, IntegrityAlgorithm::Sha256] {
             let credentials = ShortTermCredentials::new("secret".to_owned()).into();
             let mut msg = Message::builder_request(BINDING);
@@ -1790,7 +1788,7 @@ mod tests {
 
     #[test]
     fn parse_attribute_after_fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let mut bytes = msg.build();
@@ -1807,7 +1805,7 @@ mod tests {
 
     #[test]
     fn add_attribute_after_fingerprint() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let software = Software::new("s").unwrap();
@@ -1819,7 +1817,7 @@ mod tests {
 
     #[test]
     fn parse_truncated_message_header() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let bytes = msg.build();
@@ -1834,7 +1832,7 @@ mod tests {
 
     #[test]
     fn parse_truncated_message() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let bytes = msg.build();
@@ -1849,7 +1847,7 @@ mod tests {
 
     #[test]
     fn parse_truncated_message_attribute() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         msg.add_fingerprint().unwrap();
         let mut bytes = msg.build();
@@ -1866,7 +1864,7 @@ mod tests {
 
     #[test]
     fn valid_attributes() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut src = Message::builder_request(BINDING);
         let username = Username::new("123").unwrap();
         src.add_attribute(&username).unwrap();
@@ -1914,6 +1912,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "created from a non-request message")]
     fn builder_success_panic() {
+        let _log = crate::tests::test_init_log();
         let msg = Message::builder(
             MessageType::from_class_method(MessageClass::Indication, BINDING),
             TransactionId::generate(),
@@ -1926,6 +1925,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "created from a non-request message")]
     fn builder_error_panic() {
+        let _log = crate::tests::test_init_log();
         let msg = Message::builder(
             MessageType::from_class_method(MessageClass::Indication, BINDING),
             TransactionId::generate(),
@@ -1938,6 +1938,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Use add_message_integrity() instead")]
     fn builder_add_attribute_integrity_panic() {
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         let hmac = [2; 20];
         let integrity = MessageIntegrity::new(hmac);
@@ -1947,6 +1948,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Use add_message_integrity() instead")]
     fn builder_add_attribute_integrity_sha256_panic() {
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         let hmac = [2; 16];
         let integrity = MessageIntegritySha256::new(&hmac).unwrap();
@@ -1956,6 +1958,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Use add_fingerprint() instead")]
     fn builder_add_attribute_fingerprint_panic() {
+        let _log = crate::tests::test_init_log();
         let mut msg = Message::builder_request(BINDING);
         let fingerprint = [2; 4];
         let integrity = Fingerprint::new(fingerprint);
@@ -1964,7 +1967,7 @@ mod tests {
 
     #[test]
     fn rfc5769_vector1() {
-        init();
+        let _log = crate::tests::test_init_log();
         // https://tools.ietf.org/html/rfc5769#section-2.1
         let data = vec![
             0x00, 0x01, 0x00, 0x58, // Request type message length
@@ -2063,7 +2066,7 @@ mod tests {
 
     #[test]
     fn rfc5769_vector2() {
-        init();
+        let _log = crate::tests::test_init_log();
         // https://tools.ietf.org/html/rfc5769#section-2.2
         let data = vec![
             0x01, 0x01, 0x00, 0x3c, // Response type message length
@@ -2140,7 +2143,7 @@ mod tests {
 
     #[test]
     fn rfc5769_vector3() {
-        init();
+        let _log = crate::tests::test_init_log();
         // https://tools.ietf.org/html/rfc5769#section-2.3
         let data = vec![
             0x01, 0x01, 0x00, 0x48, // Response type and message length
@@ -2220,7 +2223,7 @@ mod tests {
 
     #[test]
     fn rfc5769_vector4() {
-        init();
+        let _log = crate::tests::test_init_log();
         // https://tools.ietf.org/html/rfc5769#section-2.4
         let data = vec![
             0x00, 0x01, 0x00, 0x60, //    Request type and message length
@@ -2305,7 +2308,7 @@ mod tests {
 
     #[test]
     fn rfc8489_vector1() {
-        init();
+        let _log = crate::tests::test_init_log();
         // https://www.rfc-editor.org/rfc/rfc8489#appendix-B.1
         // https://www.rfc-editor.org/errata/eid6268
         let data = vec![


### PR DESCRIPTION
Uses `tracing_subscriber`'s `TestWriter` to put logs into the cargo test output.