### PR TITLE
build: move arbitrary derive feature to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [workspace.dependencies]
-arbitrary = "1"
+arbitrary = { version = "1", features = ["derive"] }
 byteorder = "1"
 rand = "0.8"
 tracing = "0.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { workspace = true, features = ["derive"] }
+arbitrary.workspace = true
 libfuzzer-sys = "0.4"
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"]}


### PR DESCRIPTION
We always need the derive macro when we need the arbitrary dep.