### PR TITLE
types: depend on sha1 instead of sha-1

### DIFF
--- a/stun-types/Cargo.toml
+++ b/stun-types/Cargo.toml
@@ -17,7 +17,7 @@ crc = "3"
 hmac = "0.12"
 md-5 = "0.10"
 rand.workspace = true
-sha-1 = "0.10"
+sha1 = "0.10"
 sha2 = "0.10"
 tracing.workspace = true
 arbitrary ={ workspace = true, optional = true }


### PR DESCRIPTION
The upstream create was renamed and the old name is deprecated.

Fixes https://github.com/ystreet/stun-proto/issues/43