### PR TITLE
agent: add case for handling unvalidated stun

### DIFF
--- a/stun-proto/examples/stund.rs
+++ b/stun-proto/examples/stund.rs
@@ -61,7 +61,8 @@ fn handle_incoming_data<'a>(
     let reply = stun_agent.handle_stun(msg, from);
     match reply {
         HandleStunReply::Drop => None,
-        HandleStunReply::StunResponse(_response) => {
+        HandleStunReply::ValidatedStunResponse(_response)
+        | HandleStunReply::UnvalidatedStunResponse(_response) => {
             error!("received unexpected STUN response from {from}!");
             None
         }

--- a/stun-proto/src/lib.rs
+++ b/stun-proto/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! // If running over TCP then there may be multiple messages parsed. However UDP will only ever
 //! // have a single message per datagram.
-//! assert!(matches!(reply, HandleStunReply::StunResponse(_)));
+//! assert!(matches!(reply, HandleStunReply::ValidatedStunResponse(_)));
 //!
 //! // Once valid STUN data has been sent and received, then data can be sent and received from the
 //! // peer.


### PR DESCRIPTION
Within TURN, the STALE_NONCE error response will not contain the relevant message integrity and will fail integrity checks.  The caller still needs access to the message in this case to perform further processing.