### PR TITLE
proto: expose Instant type as public API

### DIFF
--- a/stun-proto/src/agent.rs
+++ b/stun-proto/src/agent.rs
@@ -23,7 +23,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::time::Duration;
 
-use sans_io_time::Instant;
+use crate::Instant;
 
 use byteorder::{BigEndian, ByteOrder};
 

--- a/stun-proto/src/lib.rs
+++ b/stun-proto/src/lib.rs
@@ -83,6 +83,7 @@ extern crate std;
 
 pub mod agent;
 
+pub use sans_io_time::Instant;
 pub use stun_types as types;
 
 #[derive(Clone)]


### PR DESCRIPTION
It is required for Agent use and this way we do not need to require users to match the same version of the sans-io-time crate.