### PR TITLE
Cache hashing state for integrity calculations

### DIFF
--- a/stun-types/Cargo.toml
+++ b/stun-types/Cargo.toml
@@ -31,7 +31,7 @@ criterion.workspace = true
 
 [features]
 default = ["std"]
-std = ["thiserror/std", "rand/thread_rng"]
+std = ["thiserror/std", "rand/thread_rng", "hmac/reset"]
 arbitrary = ["dep:arbitrary"]
 
 [[bench]]


### PR DESCRIPTION
Saves 30% on message parsing/writing with the same key,