### PR TITLE
Add some minor functionality to `Message`

### DIFF
--- a/stun-proto/examples/stund.rs
+++ b/stun-proto/examples/stund.rs
@@ -58,7 +58,7 @@ fn handle_incoming_data(
     let msg = Message::from_bytes(data).ok()?;
     let reply = stun_agent.handle_stun(msg, from);
     match reply {
-        HandleStunReply::Drop => None,
+        HandleStunReply::Drop(_) => None,
         HandleStunReply::ValidatedStunResponse(_response)
         | HandleStunReply::UnvalidatedStunResponse(_response) => {
             error!("received unexpected STUN response from {from}!");

--- a/stun-proto/src/agent.rs
+++ b/stun-proto/src/agent.rs
@@ -239,7 +239,7 @@ impl StunAgent {
         if msg.is_response() {
             let Some(request) = self.take_outstanding_request(&msg.transaction_id()) else {
                 trace!("original request disappeared -> ignoring response");
-                return HandleStunReply::Drop;
+                return HandleStunReply::Drop(msg);
             };
             // only validate response if the original request had credentials
             if request.request_had_credentials {
@@ -741,7 +741,7 @@ pub enum HandleStunReply<'a> {
     /// The provided data could be parsed as a STUN message.
     IncomingStun(Message<'a>),
     /// Drop this message.
-    Drop,
+    Drop(Message<'a>),
 }
 
 /// STUN errors
@@ -879,7 +879,7 @@ pub(crate) mod tests {
         let response = Message::from_bytes(&resp_data).unwrap();
         // response without a request is dropped.
         let ret = agent.handle_stun(response, remote_addr);
-        assert!(matches!(ret, HandleStunReply::Drop));
+        assert!(matches!(ret, HandleStunReply::Drop(_)));
     }
 
     #[test]
@@ -1277,7 +1277,7 @@ pub(crate) mod tests {
 
         let response = Message::from_bytes(&data).unwrap();
         let reply = agent.handle_stun(response, to);
-        assert!(matches!(reply, HandleStunReply::Drop));
+        assert!(matches!(reply, HandleStunReply::Drop(_)));
     }
 
     #[test]

--- a/stun-types/src/message.rs
+++ b/stun-types/src/message.rs
@@ -820,7 +820,7 @@ impl MessageHeader {
 ///
 /// Contains the [`MessageType`], a transaction ID, and a list of STUN
 /// [`Attribute`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Message<'a> {
     data: &'a [u8],
 }
@@ -1687,6 +1687,11 @@ impl<'a> Message<'a> {
     pub fn has_attribute(&self, atype: AttributeType) -> bool {
         self.iter_attributes()
             .any(|(_offset, attr)| attr.get_type() == atype)
+    }
+
+    /// Returns the underlying slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data
     }
 }
 impl<'a> TryFrom<&'a [u8]> for Message<'a> {


### PR DESCRIPTION
1. `HandleStunReply::Drop` now returns the message similar to all other enum variants. This helps me with forwarding the message to another STUN client, *str0m* in my case, simply by moving ownership.
2. `Message` can be `Copy` because it is just a reference and cheap to clone. Also I need access to its underlying slice to wrap it in *str0ms* `Receive` struct. `as_bytes` allows me to do just that.