### PR TITLE
types: mark attribute_display as only available on "std"

### DIFF
--- a/stun-types/src/attribute/mod.rs
+++ b/stun-types/src/attribute/mod.rs
@@ -241,6 +241,7 @@ pub fn add_display_impl(atype: AttributeType, imp: AttributeDisplay) {
 /// assert_eq!(display_str, "MyAttribute");
 /// # }
 /// ```
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! attribute_display {
     ($typ:ty) => {{


### PR DESCRIPTION
Was unusable on non-std anyway